### PR TITLE
fix framework link error on iOS9 and older devices

### DIFF
--- a/Accengage-iOS-SDK-Extension/1.1.0/Accengage-iOS-SDK-Extension.podspec
+++ b/Accengage-iOS-SDK-Extension/1.1.0/Accengage-iOS-SDK-Extension.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.source = { :http => 'https://dl.bintray.com/accengage/iOS/AccengageKitExtension-1.1.0.zip' }
 
   s.platform = :ios
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '10.0'
 
   s.frameworks = 'CoreGraphics', 'UIKit'
   s.weak_framework = 'UserNotifications'


### PR DESCRIPTION
notification extensions are not available pre iOS10, using cocoapods will give a linking error when running on iOS9 and older devices.
======
fixes failure to run on iOS 9.* and lower:
`dyld: Library not loaded: /System/Library/Frameworks/UserNotifications.framework/UserNotifications
  Referenced from: /private/var/containers/Bundle/Application/***/***.app/Frameworks/AccengageExtension.framework/AccengageExtension
  Reason: image not found`